### PR TITLE
page improvements

### DIFF
--- a/Korp.Latvia/Korp.Latvia/Pages/Contacts.cshtml
+++ b/Korp.Latvia/Korp.Latvia/Pages/Contacts.cshtml
@@ -28,7 +28,7 @@
             <div class="col-md-4 text-center py-3">
                 <picture><source srcset="/icons/7_ikona.png" type="image/png"><img src="/icons/7_ikona.png" alt="aploksne" class="icon" /></picture>
                 <p>
-                    info@latvus.lv
+                    info [at] latvus.lv
                 </p>
             </div>
             <div class="col-md-4 text-center py-3">

--- a/Korp.Latvia/Korp.Latvia/Pages/Error.cshtml
+++ b/Korp.Latvia/Korp.Latvia/Pages/Error.cshtml
@@ -1,26 +1,30 @@
 ﻿@page
 @model ErrorModel
 @{
-    ViewData["Title"] = "Error";
+	ViewData["Title"] = "Error";
 }
 
-<h1 class="text-danger">Error.</h1>
-<h2 class="text-danger">An error occurred while processing your request.</h2>
+<br />
+<br />
+<br />
+<br />
+<br />
 
-@if (Model.ShowRequestId)
+@if (Model.ShowNotFound)
 {
-    <p>
-        <strong>Request ID:</strong> <code>@Model.RequestId</code>
-    </p>
+	<h1 class="text-info">Lapa nav atrasta.</h1>
+	<br />
 }
+else
+{
+	<h1 class="text-danger">Kļūda.</h1>
+	<h2 class="text-danger">Pieprasījuma apstrādes laikā notikusi neparedzēta kļūda </h2>
+	<h3 class ="text-danger"> Atkārto darbību vēlreiz. Ja kļūda atkārtojas - sazinies ar lapas uzturētāju</h3>
 
-<h3>Development Mode</h3>
-<p>
-    Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred.
-</p>
-<p>
-    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
-    It can result in displaying sensitive information from exceptions to end users.
-    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
-    and restarting the app.
-</p>
+	@if (Model.ShowRequestId)
+	{
+		<p>
+			<strong>Pieprasījuma ID:</strong> <code>@Model.RequestId</code>
+		</p>
+	}
+}

--- a/Korp.Latvia/Korp.Latvia/Pages/Error.cshtml
+++ b/Korp.Latvia/Korp.Latvia/Pages/Error.cshtml
@@ -1,7 +1,7 @@
 ﻿@page
 @model ErrorModel
 @{
-	ViewData["Title"] = "Error";
+    ViewData["Title"] = "Error";
 }
 
 <br />
@@ -12,19 +12,19 @@
 
 @if (Model.ShowNotFound)
 {
-	<h1 class="text-info">Lapa nav atrasta.</h1>
-	<br />
+    <h1 class="text-info">Lapa nav atrasta.</h1>
+    <br />
 }
 else
 {
-	<h1 class="text-danger">Kļūda.</h1>
-	<h2 class="text-danger">Pieprasījuma apstrādes laikā notikusi neparedzēta kļūda </h2>
-	<h3 class ="text-danger"> Atkārto darbību vēlreiz. Ja kļūda atkārtojas - sazinies ar lapas uzturētāju</h3>
+    <h1 class="text-danger">Kļūda.</h1>
+    <h2 class="text-danger">Pieprasījuma apstrādes laikā notikusi neparedzēta kļūda </h2>
+    <h3 class="text-danger"> Atkārto darbību vēlreiz. Ja kļūda atkārtojas - sazinies ar lapas uzturētāju</h3>
 
-	@if (Model.ShowRequestId)
-	{
-		<p>
-			<strong>Pieprasījuma ID:</strong> <code>@Model.RequestId</code>
-		</p>
-	}
+    @if (Model.ShowRequestId)
+    {
+        <p>
+            <strong>Pieprasījuma ID:</strong> <code>@Model.RequestId</code>
+        </p>
+    }
 }

--- a/Korp.Latvia/Korp.Latvia/Pages/Error.cshtml.cs
+++ b/Korp.Latvia/Korp.Latvia/Pages/Error.cshtml.cs
@@ -7,8 +7,10 @@ namespace Korp.Latvia.Pages
     [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
     [IgnoreAntiforgeryToken]
     public class ErrorModel : PageModel
-    {
-        public string? RequestId { get; set; }
+	{
+		public bool ShowNotFound { get; set; } 
+
+		public string? RequestId { get; set; }
 
         public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 
@@ -19,8 +21,13 @@ namespace Korp.Latvia.Pages
             _logger = logger;
         }
 
-        public void OnGet()
+        public void OnGet(int? statusCode)
         {
+            if (statusCode == 404) 
+            {
+                ShowNotFound = true;
+            }
+
             RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
         }
     }

--- a/Korp.Latvia/Korp.Latvia/Pages/Error.cshtml.cs
+++ b/Korp.Latvia/Korp.Latvia/Pages/Error.cshtml.cs
@@ -7,10 +7,10 @@ namespace Korp.Latvia.Pages
     [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
     [IgnoreAntiforgeryToken]
     public class ErrorModel : PageModel
-	{
-		public bool ShowNotFound { get; set; } 
+    {
+        public bool ShowNotFound { get; set; }
 
-		public string? RequestId { get; set; }
+        public string? RequestId { get; set; }
 
         public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 
@@ -23,7 +23,7 @@ namespace Korp.Latvia.Pages
 
         public void OnGet(int? statusCode)
         {
-            if (statusCode == 404) 
+            if (statusCode == 404)
             {
                 ShowNotFound = true;
             }

--- a/Korp.Latvia/Korp.Latvia/Pages/Index.cshtml
+++ b/Korp.Latvia/Korp.Latvia/Pages/Index.cshtml
@@ -259,7 +259,7 @@
             <div class="col-md-4">
                 <h4>Attīstība</h4>
                 <p class="mt-4">
-                    Apgūsti paukošanos, etiķeti, balles dejas u.c. Piedalies izglītojošos pasākumos.
+                    Apgūsti akadēmisko paukošanu, etiķeti, balles dejas u.c. Piedalies izglītojošos pasākumos.
                 </p>
             </div>
         </div>

--- a/Korp.Latvia/Korp.Latvia/Program.cs
+++ b/Korp.Latvia/Korp.Latvia/Program.cs
@@ -17,6 +17,11 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 
 app.UseRouting();
+app.MapGet("/kalendars", context =>
+{
+    context.Response.Redirect("https://kalendars.latvus.lv", permanent: true);
+    return Task.CompletedTask;
+});
 
 app.UseAuthorization();
 

--- a/Korp.Latvia/Korp.Latvia/Program.cs
+++ b/Korp.Latvia/Korp.Latvia/Program.cs
@@ -17,6 +17,7 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 
 app.UseRouting();
+app.UseStatusCodePagesWithRedirects("/Error?statusCode={0}");
 app.MapGet("/kalendars", context =>
 {
     context.Response.Redirect("https://kalendars.latvus.lv", permanent: true);


### PR DESCRIPTION
- redirect for latvus.lv/kalendars -> kalendars.latvus.lv
- errror handling (for example, 404)
- language usage
- email address made inconvenient for scraping